### PR TITLE
Fix crash rendering harness entries mis-owned by a component

### DIFF
--- a/src/py/altium_monkey/altium_record_sch__component.py
+++ b/src/py/altium_monkey/altium_record_sch__component.py
@@ -1734,6 +1734,16 @@ class AltiumSchComponent(SchGraphicalObject):
         )
 
         for child_kind, child in component_children:
+            # Harness/sheet entries are parent-bound primitives that require
+            # parent_* kwargs and are drawn by the dedicated harness/sheet-symbol
+            # passes. On some projects a harness entry's owner_index resolves to
+            # a component, landing it in this child list; rendering it here would
+            # call its to_geometry() without the parent_* kwargs and crash.
+            if type(child).__name__ in (
+                "AltiumSchHarnessEntry",
+                "AltiumSchSheetEntry",
+            ):
+                continue
             owner_part = getattr(child, "owner_part_id", None)
             if (
                 owner_part is not None

--- a/src/py/altium_monkey/altium_schdoc.py
+++ b/src/py/altium_monkey/altium_schdoc.py
@@ -3325,6 +3325,13 @@ class AltiumSchDoc(JsonApplyMixin):
         ):
             if is_component_owned(obj) or is_template_owned(obj):
                 continue
+            # Parent-bound primitives (harness entries, sheet entries) are
+            # positioned relative to a parent connector/symbol and require
+            # parent_* kwargs the generic dispatch cannot supply. They are
+            # rendered by the dedicated harness/sheet-symbol passes, so skip
+            # them here (mirrors the template-child guard below).
+            if isinstance(obj, (AltiumSchHarnessEntry, AltiumSchSheetEntry)):
+                continue
             geometry_record = obj.to_geometry(
                 geometry_ctx,
                 document_id=document_id,
@@ -3350,6 +3357,11 @@ class AltiumSchDoc(JsonApplyMixin):
             objects, key=lambda item: str(getattr(item, "unique_id", ""))
         ):
             if should_skip(obj):
+                continue
+            # Parent-bound primitives (harness entries, sheet entries) require
+            # parent_* kwargs the generic dispatch cannot supply; they are drawn
+            # by the dedicated harness/sheet-symbol passes. Skip defensively.
+            if isinstance(obj, (AltiumSchHarnessEntry, AltiumSchSheetEntry)):
                 continue
             to_geometry = getattr(obj, "to_geometry", None)
             if not callable(to_geometry):
@@ -3847,6 +3859,15 @@ class AltiumSchDoc(JsonApplyMixin):
             getattr(comp, "graphics", []),
             key=lambda obj: str(getattr(obj, "unique_id", "")),
         ):
+            # Harness/sheet entries are parent-bound primitives drawn by the
+            # dedicated harness/sheet-symbol passes; if one is mis-owned by a
+            # component it lands in comp.graphics, and rendering it here would
+            # call to_geometry() without the required parent_* kwargs.
+            if type(graphic).__name__ in (
+                "AltiumSchHarnessEntry",
+                "AltiumSchSheetEntry",
+            ):
+                continue
             if not record_belongs_to_display_mode(graphic, component_display_mode):
                 continue
             owner_part = getattr(graphic, "owner_part_id", None)


### PR DESCRIPTION
AltiumSchHarnessEntry.to_geometry() requires parent_* keyword-only args that are supplied only by the dedicated harness-connector geometry pass. When a harness entry's owner_index resolves to a component it is collected into that component's graphics and drawn via the component/generic geometry loops, which call to_geometry() with the generic argument set and crash the whole sheet render with a TypeError.

Skip harness/sheet entries in the component-child loop, the two component- graphics loops, and the generic geometry dispatchers, so they are only drawn by the dedicated harness pass. Mirrors the existing template-child guard.

## Contribution Notice

Thanks for the PR. Please note that this repository is a published mirror for a
project developed in a separate upstream workspace.

Pull requests are welcome when they help demonstrate intent, expected behavior,
API shape, a failing case, or a possible implementation strategy. PRs may not be
merged directly. Accepted changes may be adapted or rewritten in the upstream
source tree, validated there, and mirrored back in a later package version.

## Summary

Schematic SVG generation (`AltiumSchDoc.to_svg()` / `altium-cruncher design`) aborts with a
`TypeError` when a schematic contains a **harness entry whose `owner_index` resolves to a component**.

`AltiumSchHarnessEntry.to_geometry()` is a *parent-bound* primitive: on top of the usual
`document_id` / `units_per_px`, it requires five keyword-only arguments describing the parent
connector's box — `parent_x`, `parent_y`, `parent_width`, `parent_height`, `parent_orientation`.
Those are supplied only by the dedicated harness-connector geometry pass.

When an entry is owner-attributed to a component, it is collected into that component's `graphics`
list and drawn by the **component child-geometry path**, which uses the generic call
`obj.to_geometry(ctx, document_id=…, units_per_px=…)` — missing the five required kwargs → crash,
which aborts the entire sheet render.

The fix skips harness/sheet entries in the component-child and generic geometry loops, so they are
only ever drawn by the dedicated harness pass. This mirrors an existing guard already present in the
template-child loop of `altium_schdoc.py` (same rationale, same comment). **2 files, +31 lines, no
removals.**

Guard sites added:

| File · function | Role |
|---|---|
| `altium_record_sch__component.py` · `AltiumSchComponent.to_geometry()` child loop | **Essential** — the frame in the traceback |
| `altium_schdoc.py` · `_append_component_graphics_parameters_and_pins()` | **Essential** — 2nd loop over the same `comp.graphics` |
| `altium_schdoc.py` · `_append_top_level_geometry_records()` | Defensive — same generic-call hazard, other path |
| `altium_schdoc.py` · `_append_callable_geometry_records()` | Defensive — same, sibling dispatcher |

In the component module the check uses `type(child).__name__ in (...)` to avoid a circular import;
the `altium_schdoc.py` sites use `isinstance(...)` since the classes are already in scope there.

## Reproduction

A self-contained failing `.SchDoc` is attached: **`harness_repro_schdoc.zip`** →
`harness_entry_owned_by_component.SchDoc`. Rendering it raises the crash on `main` and succeeds with this
patch — so it also serves as a regression test.

```python
from altium_monkey import AltiumSchDoc
AltiumSchDoc("harness_entry_owned_by_component.SchDoc").to_svg()
#   on main        -> TypeError (below)
#   with this PR   -> returns an SVG string (~297 KB)
```

Observed on `main`:

```
File ".../altium_monkey/altium_schdoc.py", line 4845, in to_ir
    return self.to_geometry(...)
File ".../altium_monkey/altium_schdoc.py", line 3792, in _append_single_component_geometry_records
    geometry_record = comp.to_geometry(...)
File ".../altium_monkey/altium_record_sch__component.py", line 1758, in to_geometry
    graphic_record = to_geometry(ctx, document_id=document_id, units_per_px=units_per_px)
TypeError: AltiumSchHarnessEntry.to_geometry() missing 5 required keyword-only arguments:
'parent_x', 'parent_y', 'parent_width', 'parent_height', and 'parent_orientation'
```

**How the fixture was built (fully from public repo assets):** I first rendered all 53 bundled `.SchDoc`
assets — 5 contain harness objects (`hydroscope/CPU`, `hydroscope/TOP_LEVEL`, `hydroscope/US_IF`,
`loz-old-man/Flash Memory`, `loz-old-man/LCD_IO`) but **none reproduce the crash**, because their harness
entries are correctly owned by their connectors. The bug needs the specific condition where an entry's
`OWNERINDEX` resolves to a *component* (so it lands in `comp.graphics`, one of `COMPONENT_GRAPHIC_CHILD_TYPES`).
The fixture is `examples/assets/projects/hydroscope/CPU.SchDoc` with a single harness entry (`HV_ON`)
re-parented from its connector onto a component, saved into the main record stream — the exact
real-world shape that first surfaced this. No proprietary files involved.

*(The original board that surfaced it is proprietary; this public fixture reproduces the identical failure.)*

## Notes

- **Rendering only.** No change to netlisting, parsing, writing, or round-trip; nothing in the object
  model changes, only which geometry loop is allowed to draw a parent-bound primitive.
- **No visual loss.** Harness entries are still drawn by the dedicated harness-connector pass, which
  passes the correct `parent_*` values. The guards only prevent a second, invalid draw through the
  component/generic paths.
- **Consistent with existing intent.** The template-child loop in `altium_schdoc.py` already skips
  `AltiumSchHarnessEntry` / `AltiumSchSheetEntry` for exactly this reason; this extends the same guard to
  the loops that were missing it.
- Root cause (an entry's `owner_index` pointing at a component) may itself be worth investigating
  upstream in the attach/ownership logic; this PR is the defensive render-side guard.

---
[harness_repro_schdoc.zip](https://github.com/user-attachments/files/29669879/harness_repro_schdoc.zip)
