### PR TITLE
prjpcb: fix issue supporting nested folders

### DIFF
--- a/src/py/altium_monkey/altium_prjpcb.py
+++ b/src/py/altium_monkey/altium_prjpcb.py
@@ -1257,7 +1257,7 @@ class AltiumPrjPcb:
             doc_path = doc["path"]
             if not doc_path.lower().endswith(ext):
                 continue
-            full_path = (project_dir / doc_path.replcae("\\","/")).resolve()
+            full_path = (project_dir / doc_path.replace("\\","/")).resolve()
             if full_path.exists():
                 matched_paths.append(full_path)
         return matched_paths

--- a/src/py/altium_monkey/altium_prjpcb.py
+++ b/src/py/altium_monkey/altium_prjpcb.py
@@ -1257,7 +1257,7 @@ class AltiumPrjPcb:
             doc_path = doc["path"]
             if not doc_path.lower().endswith(ext):
                 continue
-            full_path = (project_dir / doc_path).resolve()
+            full_path = (project_dir / doc_path.replcae("\\","/")).resolve()
             if full_path.exists():
                 matched_paths.append(full_path)
         return matched_paths


### PR DESCRIPTION

## Summary

Hi! I was starting to work with this project and was getting issues with missing schematics.

in my case, I use windows for altium, and WSL for python scripting.

as such, my altium prjpcb paths all use reverse backslash.

My project structure contains the following shape

```
Project_folder
|
->
project.PrjPcb
schematics
|
-> [ location where all schematics are]
```

as such, the document paths are for example: `DocumentPath=schematics\m2_emmc.SchDoc`

the resulting doc_path in this context then becomes:
`schematics\\m2_emmc.SchDoc`
which then fails to resolve in `_get_document_paths_by_extension`

attached PR follows what is done in most locations in the code and just corrects the doc_path before proceeding.

I've tested this on the repo by modifying the m2_emmc asset to comply with the structure mentioned above.

I then ran `schdoc_svg.py` (modified with the different project) and successfully generated an svg output.

thanks again, hoping this can be merged or fixed quickly! :)
