### PR TITLE
Name IPC-2581 pins by pad designator

### DIFF
--- a/src/py/altium_monkey/altium_pcb_ipc2581_writer.py
+++ b/src/py/altium_monkey/altium_pcb_ipc2581_writer.py
@@ -4101,7 +4101,8 @@ def _build_component_pad_order(
             continue
         comp_ref = dedup_map.get(comp_idx) or comp.designator
         for pin_num, pad_idx in enumerate(pad_indices, 1):
-            comp_pad_map[pad_idx] = (comp_ref, str(pin_num))
+            pad = pcbdoc.pads[pad_idx]
+            comp_pad_map[pad_idx] = (comp_ref, pad.designator or str(pin_num))
             ordered_pad_items.append((pad_idx, pcbdoc.pads[pad_idx]))
             ordered_pad_indices.add(pad_idx)
 


### PR DESCRIPTION
Refs #39.

PinRef entries were numbered from the order pads appear in the PcbDoc, while the package pins they point at are named from each pad's stored designator. When a footprint's pad order differs from its designator order, the PinRef ends up aimed at the wrong package pin, so nets are attributed to the wrong pins. Geometry is unaffected.

The change uses the parsed pad designator for PinRef.pin, keeping sequential numbering only as a fallback for blank designators.

Verified on two boards by comparing against Altium Designer's own IPC-2581 export of the same PcbDoc:

- a 86-component board: 219 connectivity membership contradictions before, 0 after
- the goomba reference board in examples/: 111 per-pin net disagreements before, 0 after

Element counts, layer definitions, component counts and package counts are unchanged on both. Branched from v2026.7.29; the same line is present in 2026.8.11.post1 at altium_pcb_ipc2581_writer.py:4326.

I understand this repo is a mirror and that changes are usually reworked upstream rather than merged as submitted, so treat this as a proposal.