### PR TITLE
Use the document's own channel index when naming channels

### DIFF
--- a/src/py/altium_monkey/altium_design_compiler.py
+++ b/src/py/altium_monkey/altium_design_compiler.py
@@ -1904,7 +1904,7 @@ def _room_details_for_compiled_naming(
         ),
     )
     if "$RoomName" not in channel_designator_format:
-        index = instance_offset + 1
+        index = document.channel_index or instance_offset + 1
         room = replace(
             room,
             channel_prefix=document.room_name or room.channel_prefix,


### PR DESCRIPTION
Refs #40.

`_room_details_for_compiled_naming()` ignores the physical document's `channel_index` whenever the channel designator format has no `$RoomName`, and uses the document's position in the instantiation list instead. That position follows the order the sheet-symbol records sit in the file, not the channel order.

On a project whose Power.SchDoc stores the symbol designated PSU_2 before PSU_1, room PSU_1's parts compile as U2_2, C9_2 … and room PSU_2's as U2_1, C9_1 … — reversed against what Altium writes to the PcbDoc and its own netlist. The same room details feed `_physical_channel_net_name()`, so channel-scoped net names swap with them. Connectivity then reads onto the wrong physical part: on the board that turned this up, one regulator channel's decoupling appears on the other.

The document's `channel_index` is already correct — `_multi_reference_channel_rooms()` sorts symbols by designator and `_build_room_details()` reads the trailing digits, so PSU_1 resolves to 1. This uses that index and falls back to the instantiation offset only when the document has none, so rooms without a channel index behave as before.

Verified on a multi-channel project whose sheet-symbol records are out of designator order: all 18 repeated-channel components now match the PcbDoc's SOURCEUNIQUEID / SOURCEDESIGNATOR pairs, and the channel nets match the Protel netlist (RT_1, RT_2, PSU_FB_1).

Compiling every project under examples/assets/projects before and after gives identical components and nets, including simple_hierchical, which uses the same `$Component_$ChannelIndex` format and exercises the changed branch. `pytest tests/` is unchanged: 171 passed, with the two CadQuery-dependent tests failing the same way on both trees.

The reproducing project is customer hardware and cannot be published, so there is no asset test with it.

Two things noticed while reproducing, not addressed here:

- The same project trips `unresolved_sheet_symbol_child` because its sheet symbols name children without the `.SchDoc` extension — that is #38.
- After this fix the second channel net has the right membership but is still named `PSU_FB` rather than `PSU_FB_2`: in the flat merge the parent sheet's explicit label wins over the channel-scoped name. Present before and after this change; happy to file it separately if useful.

As with #41, I understand this repo is a mirror and changes are usually reworked upstream, so treat this as a proposal.